### PR TITLE
Use yaml.safeLoad instead of load

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = async robot => {
 
     try {
       const data = await github.repos.getContent({owner, repo, path});
-      config = yaml.load(new Buffer(data.content, 'base64').toString()) || {};
+      config = yaml.safeLoad(new Buffer(data.content, 'base64').toString()) || {};
       config.exists = true;
     } catch (err) {
       robot.log.debug(err, 'No configuration file found');


### PR DESCRIPTION
Fixes issue where untrusted yaml file could contain JavaScript: https://github.com/nodeca/js-yaml#safeload-string---options-

cc @lee-dohm 