### PR TITLE
Prevent issues from getting closed too early.

### DIFF
--- a/lib/no-response.js
+++ b/lib/no-response.js
@@ -1,3 +1,5 @@
+const scramjet = require('scramjet')
+
 module.exports = class NoResponse {
   constructor (context, config, logger) {
     this.context = context
@@ -55,12 +57,12 @@ module.exports = class NoResponse {
     })
   }
 
-  async findLastLabeledEvent ({owner, repo, number}) {
+  async findLastLabeledEvent (owner, repo, number) {
     const {responseRequiredLabel} = this.config
     const params = {owner, repo, issue_number: number, per_page: 100}
     const events = await this.github.paginate(this.github.issues.getEvents(params))
-    return events.reverse()
-                 .find(event => event.event === 'labeled' && event.label.name === responseRequiredLabel)
+    return events[0].data.reverse()
+                 .find(event => event.event === 'labeled' && event.label.name === responseRequiredLabel);
   }
 
   async getClosableIssues () {
@@ -71,14 +73,13 @@ module.exports = class NoResponse {
     const labeledEarlierThan = this.since(daysUntilClose)
 
     const issues = await this.github.search.issues(params)
-    return issues.data.items.filter(async issue => {
-      const event = await this.findLastLabeledEvent(issue)
+    const closableIssues = scramjet.fromArray(issues.data.items).filter(async issue => {
+      const event = await this.findLastLabeledEvent(owner, repo, issue.number)
+      const creationDate = new Date(event.created_at)
 
-      if (event.created_at < labeledEarlierThan) {
-        issue.labeled = event.created_at
-        return issue
-      }
-    })
+      return creationDate < labeledEarlierThan
+    }).toArray()
+    return closableIssues
   }
 
   async hasResponseRequiredLabel (issue) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "probot": "^3.0.2",
-    "probot-scheduler": "^1.0.2"
+    "probot-scheduler": "^1.0.2",
+    "scramjet": "^4.0.1"
   },
   "devDependencies": {
     "eslint-config-probot": "^0.1.0",
@@ -27,7 +28,7 @@
   },
   "standard": {
     "env": [
-        "mocha"
+      "mocha"
     ]
   }
 }


### PR DESCRIPTION
This PR fixes a small number of issues which result in issues being closed too early. The github response structures for fetching issue events was a bit off, the check if a label is too old compared a string to a date object and the `filter` call using this check was not waiting for the `async` filter function to complete. Instead it returned `true` for all elements because `Promise != false`.

* Fixing usage of issue/events response structure.

* Fixing check if label is too old.

* Using scramjet to filter using async function.

Fixes probot/no-response#12