### PR TITLE
If OP closed issue, don't reopen issue when OP posts comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When an `issue_comment` event is received, if all of the following are true:
 It will:
 
 1. Remove the `responseRequiredLabel`
-1. Reopen the issue if it was closed
+1. Reopen the issue if it was closed by someone other than the original author of the issue
 
 ## Usage
 

--- a/lib/no-response.js
+++ b/lib/no-response.js
@@ -29,7 +29,7 @@ module.exports = class NoResponse {
       if (perform) {
         this.logger.info('%s/%s#%d is being unmarked', owner, repo, number)
         await this.github.issues.removeLabel({owner, repo, number, name: responseRequiredLabel})
-        if (issueInfo.data.state === 'closed') {
+        if (issueInfo.data.state === 'closed' && issueInfo.data.user.login !== issueInfo.data.closed_by.login) {
           this.github.issues.edit({owner, repo, number, state: 'open'})
         }
       } else {

--- a/lib/no-response.js
+++ b/lib/no-response.js
@@ -24,7 +24,8 @@ module.exports = class NoResponse {
 
     const issueInfo = await this.github.issues.get(issue)
 
-    if (this.hasResponseRequiredLabel(issue) && issueInfo.data.user.login === comment.user.login) {
+    const isMarked = await this.hasResponseRequiredLabel(issue)
+    if (isMarked && issueInfo.data.user.login === comment.user.login) {
       if (perform) {
         this.logger.info('%s/%s#%d is being unmarked', owner, repo, number)
         await this.github.issues.removeLabel({owner, repo, number, name: responseRequiredLabel})

--- a/test/no-response-test.js
+++ b/test/no-response-test.js
@@ -187,6 +187,7 @@ describe('NoResponse', function () {
     beforeEach(function () {
       issueProperties = {
         state: 'open',
+        closed_by: null,
         user: {
           login: 'some-issue-author'
         },
@@ -202,7 +203,8 @@ describe('NoResponse', function () {
             return Promise.resolve({
               data: {
                 state: issueProperties.state,
-                user: issueProperties.user
+                user: issueProperties.user,
+                closed_by: issueProperties.closed_by
               }
             })
           },
@@ -281,9 +283,10 @@ describe('NoResponse', function () {
           expect(args.name).toBe('more-information-needed')
         })
 
-        describe('when the issue is closed', function () {
+        describe('when the issue is closed by someone other than the issue author', function () {
           it('reopens the issue', async function () {
             issueProperties.state = 'closed'
+            issueProperties.closed_by = { login: 'some-other-user' }
 
             await noResponse.unmark(context.payload.issue)
             expect(github.issues.edit).toHaveBeenCalled()
@@ -292,6 +295,16 @@ describe('NoResponse', function () {
             expect(args.repo).toBe('testing-things')
             expect(args.number).toBe(1234)
             expect(args.state).toBe('open')
+          })
+        })
+
+        describe('when the issue is closed by the issue author', function () {
+          it('leaves the issue closed', async function () {
+            issueProperties.state = 'closed'
+            issueProperties.closed_by = { login: 'some-issue-author' }
+
+            await noResponse.unmark(context.payload.issue)
+            expect(github.issues.edit).toNotHaveBeenCalled()
           })
         })
 


### PR DESCRIPTION
Fixes #16

---

The proposed fix is the small, one-line change in d3e097511966db5486d4d08ac612359e51387e15. That fix is preceded by adding tests for the [existing `unmark` functionality](https://github.com/probot/no-response/blob/a32051df0f886df7b931f137287d3391fd2dcbfd/lib/no-response.js#L20-L38) to hopefully avoid regressions.

Overall, this pull request takes the following approach:

1. 01cb842289d4cb5f145ddff9e121d37258b9aee9 adds tests for the [existing `unmark` functionality](https://github.com/probot/no-response/blob/a32051df0f886df7b931f137287d3391fd2dcbfd/lib/no-response.js#L20-L38). I've tried to follow the patterns set forth by the other tests. If I've overlooked anything, please let me know. 🙏 
1. bf92bfb2337f54ae03f3a3c800082fce735b395f fixes a bug revealed by the new tests. Because `hasResponseRequiredLabel` returns a Promise, the return value of `hasResponseRequiredLabel` is truthy. The `if` statement needs to resolve the promise and check that value's truthiness, instead of checking the truthiness of the Promise itself.
1. d3e097511966db5486d4d08ac612359e51387e15 fixes #16. We're addressing the scenario where probot/no-response is reacting to a new issue comment on a closed issue, and the issue comment is from the issue author (i.e., the person we were waiting for a response from):
    - If the issue was closed by someone else (e.g., a maintainer or probot/no-response), then we re-open the issue now that we have a comment from the person we were waiting for a response from
    - If the issue was closed by the issue author, we leave the issue closed (since the person commenting is the person that closed the issue in the first place)
