### PR TITLE
Modernize config and dependencies for easier local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ DRY_RUN=true
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=debug
+
+# For local development, go to https://smee.io/new set this to the URL that you
+# are redirected to
+WEBHOOK_PROXY_URL=

--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ WEBHOOK_SECRET=development
 
 # Uncomment to not actually mark issues
 DRY_RUN=true
+
+# Use `trace` to get verbose logging or `info` to show less
+LOG_LEVEL=debug

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">= 8.3.0"
   },
   "dependencies": {
-    "probot": "^3.0.2",
+    "probot": "^7.0.0",
     "probot-scheduler": "^1.0.2",
     "scramjet": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/probot/no-response",
   "scripts": {
     "fix": "standard --fix",
+    "dev": "nodemon",
     "start": "probot run ./index.js",
     "test": "mocha && standard"
   },
@@ -23,11 +24,20 @@
     "expect": "^1.20.2",
     "localtunnel": "^1.8.3",
     "mocha": "^4.0.1",
+    "nodemon": "^1.17.2",
+    "smee-client": "^1.0.2",
     "standard": "^10.0.3"
   },
   "standard": {
     "env": [
       "mocha"
+    ]
+  },
+  "nodemonConfig": {
+    "exec": "npm start",
+    "watch": [
+      ".env",
+      "."
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "probot": "^7.0.0",
-    "probot-scheduler": "^1.0.2",
+    "probot-scheduler": "^1.2.0",
     "scramjet": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "test": "mocha && standard"
   },
   "engines": {
-    "node": "^7.7",
-    "npm": "^4.0"
+    "node": ">= 8.3.0"
   },
   "dependencies": {
     "probot": "^3.0.2",


### PR DESCRIPTION
This pull request updates the app's dependencies and configuration to more closely match what you get when creating a new probot app when following the [latest docs for creating a new probot app](https://probot.github.io/docs/development/#generating-a-new-app) using [probot/create-probot-app](https://github.com/probot/create-probot-app).

These changes enable you to use [`npm run dev` to run the app locally](https://probot.github.io/docs/development/#running-the-app-locally), which allows your local instance to receive and respond to events from a live github.com repository. This is super helpful for local dev, experimentation, and debugging. :sparkles: 
