### PR TITLE
If failure occurs when posting close comment, don't close issue

### DIFF
--- a/lib/no-response.js
+++ b/lib/no-response.js
@@ -43,10 +43,10 @@ module.exports = class NoResponse {
 
     if (perform) {
       this.logger.info('%s/%s#%d is being closed', issue.owner, issue.repo, issue.number)
-      await this.github.issues.edit(Object.assign({}, issue, {state: 'closed'}))
       if (closeComment) {
-        return this.github.issues.createComment(Object.assign({}, issue, {body: closeComment}))
+        await this.github.issues.createComment(Object.assign({}, issue, {body: closeComment}))
       }
+      return this.github.issues.edit(Object.assign({}, issue, {state: 'closed'}))
     } else {
       this.logger.info('%s/%s#%d would have been closed (dry-run)', issue.owner, issue.repo, issue.number)
     }


### PR DESCRIPTION
Fixes #24 ... probably 🤞

### Context

https://github.com/probot/no-response/issues/24 describes a problem where probot/no-response sometimes closes an issue without posting a comment. We suspect that probot/no-response is attempting to post a comment but is having the comment rejected by GitHub's abuse prevention rate limits, similar to the issue experienced by probot/stale in https://github.com/probot/stale/issues/26.

### Proposed remedy

Following the approach implemented in https://github.com/probot/stale/pull/64, this pull request updates probot/no-response to first attempt to post the comment saying that it is closing the issue. If it successfully posts the comment, then it closes the issue. If an error occurs when posting the comment, it does not close the issue.

### Verification process

Using a [locally-running instance](https://probot.github.io/docs/development/#running-the-app-locally) of probot/no-response:

1. Install the local probot/no-response app on a repository on github.com
2. Ensure that the repository has an issue that has gone more than `daysUntilClose` without a response from the issue author
3. Test the behavior affected by this pull request:
    - [x] Run the `sweep` function and use [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) to block the HTTP request that attempts to post the comment. Verify that the comment is not posted and the issue is not closed.
    - [x] Configure Little Snitch to allow all HTTP requests to flow in/out of the app. Run the `sweep` function and verify that it leaves a comment and closes the issue.

---

/cc @lee-dohm for review